### PR TITLE
50 50

### DIFF
--- a/site/js/national-result.js
+++ b/site/js/national-result.js
@@ -33,7 +33,6 @@ function drawNationalResults(error, data) {
 			.attr('class', 'national-item' + (winningPct === thisPct ? ' win' : ' lose'))
 			.append('div')
 			.attr('class', 'total-bar')
-			.text(`${window.RESULT_LABEL[result]} ${thisPct}'%`)
 			.text(resultLabel)
 			.style('background-color', winningPct === thisPct ? WIN_BLUE : LOSE_BLUE)
 			.style('width', thisPct * 100 / winningPct + '%');


### PR DESCRIPTION
Some feedback I got is that when the result is something like 49.8% to 50.2%, because we round up numbers, we ended up with:
<img width="500" alt="screen shot 2016-05-25 at 16 34 44" src="https://cloud.githubusercontent.com/assets/3425322/15568858/01b69432-2326-11e6-9ce5-55a68d01c77f.png">

since the width of the bar is calculated off of the actual percentage before rounding.

An alternative is to show a decimal point only when the result would otherwise round to 50%, as:
<img width="500" alt="screen shot 2016-05-26 at 09 32 23" src="https://cloud.githubusercontent.com/assets/3425322/15568906/3c0aa34e-2326-11e6-9349-5a77609fcb88.png">

while still rounding all other results, like:
<img width="500" alt="screen shot 2016-05-26 at 09 32 38" src="https://cloud.githubusercontent.com/assets/3425322/15568926/5e2951a0-2326-11e6-8aca-905ec79bef44.png">

Does this look ok to you @tomgp, @kavanagh?

An alternative to this is rounding up the result percentage _before_ drawing the bar, which would give us this:
<img width="500" alt="screen shot 2016-05-26 at 09 46 10" src="https://cloud.githubusercontent.com/assets/3425322/15568991/b845cdc6-2326-11e6-8a67-1b6bfc86aeb4.png">
While the colors can be fixed, showing two identical bars with 50% 50% on them might not seem too credible, imo.

The implementation in this branch is the first one, with the decimal point.
